### PR TITLE
Feat/entities auth

### DIFF
--- a/src/entities/auth/model/index.ts
+++ b/src/entities/auth/model/index.ts
@@ -1,2 +1,1 @@
 export {loginGoogle, loginKakao, callbackGoogle, callbackKakao} from './services/authApi';
-export {type localSignup, type localLogin} from './types/auth.type';

--- a/src/entities/auth/model/services/authApi.ts
+++ b/src/entities/auth/model/services/authApi.ts
@@ -1,9 +1,38 @@
 import { httpClient } from "shared/api";
+import { LoginType, ResetPasswordType, SignupType } from "../types/auth.type";
+import { authClient } from "shared/api/authClient";
+
+
+export const signup = async (data: SignupType) => {
+    const response = await httpClient.post("auth/signup", data);
+    return response.data;
+}
+
+export const login = async (data: LoginType) => {
+    const response = await httpClient.post("auth/login", data);
+    return response.data;
+}
+
+export const logout = async () => {
+    const response = await authClient.post("auth/logout");
+    return response.data;
+}
+
+export const refreshToken = async () => {
+    const response = await authClient.post("auth/refresh");
+    return response.data;
+}
+
+export const resetPassword = async (data: ResetPasswordType) => {
+    const response = await authClient.post("auth/password", data);
+    return response.data;
+}
+
 
 
 //OAuth API 요청 핸들러
 export const loginGoogle = async () => {
-    const response = await httpClient.get("/auth/google/login");
+    const response = await httpClient.post("/auth/google/login");
     return response.data;
 }
 

--- a/src/entities/auth/model/types/auth.type.ts
+++ b/src/entities/auth/model/types/auth.type.ts
@@ -6,19 +6,21 @@ export interface AuthState {
   resetAccessToken: () => void;
 }
 
-export interface localSignup {
+export interface SignupType {
     email: string;
     password?: string;
     nickname: string;
     contact?: string;
-    image?: string; //이미지는 빠질 수 있음
-    provider: 'local'; 
+    image?: string; 
 }
 
-export interface localLogin {
+export interface LoginType {
     email: string;
     password: string;
-    provider: 'local';
 }
 
-// google , kakao 타입은 추후 작성
+export interface ResetPasswordType {
+    currentPassword: string;
+    newPassword: string;
+    newPasswordConfirm: string;
+}

--- a/src/entities/user/model/index.ts
+++ b/src/entities/user/model/index.ts
@@ -1,4 +1,2 @@
-export {loginGoogle, loginKakao, callbackGoogle, callbackKakao} from './services/authApi';
 export {fetchLocalUser, fetchOAuthUser} from './services/userApi';
 export {type localUser, type OAuthUser} from './types/user.type';
-export {type localSignup, type localLogin} from './types/auth.type';


### PR DESCRIPTION
## 개요
- auth 엔티티 타입, api 작업 + refreshToken 인터셉터 작성
## 작업사항
- auth 엔티티 타입, api 작업
-
- refresh 토큰 인터셉터의 경우,
- - retry .플래그로 무한루프 방지
- - 리프레시 실패시 로그인 화면으로 이동하는 기능
## 주의사항
- 
