### PR TITLE
Chore: Lint-staged에 md 검사 추가 및 package-lock 검사 제외

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "semi": true,
+  "plugins": ["prettier-plugin-styled-components"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,1 @@
-{
-  "singleQuote": true,
-  "tabWidth": 2,
-  "semi": true,
-  "plugins": ["prettier-plugin-styled-components"]
-}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
     "quickfix.biome": "explicit"
-  }
+  },
+
+  // Biomme이 package-lock.json과 충돌을 일으켜 제외.
+  "exclude": ["package-lock.json"]
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     ]
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{js,ts,json,jsonc,jsx,tsx}": [
+      "npx biome check --write"
+    ],
+    "*.md": [
       "prettier --write"
     ]
   }


### PR DESCRIPTION
## 개요
- prettier는 md 파일 검사에 활용하기 위해 잔류
- biome이 계속해서 package-lock.json을 검사하면서 재시작되는 오류가 발생하여 settings.json 에 package-lock.json 검사 제외하였음. 원래 포맷대상이 아닌 파일을 검사해버려서 오류가 발생한듯 

