### PR TITLE
Feat: collection 관련 api 요청 함수 및 타입 추가 

### DIFF
--- a/src/entities/collection/services/collectionApi.ts
+++ b/src/entities/collection/services/collectionApi.ts
@@ -1,0 +1,55 @@
+import { authClient } from 'shared/api';
+import {
+  CreateCollectionRequest,
+  CreateCollectionResponse,
+  GetCollectionDetailResponse,
+  GetCollectionResponse,
+  ModifyContentsRequest,
+  UpdateCollectionRequest,
+} from '../types/collection.type';
+
+export const createCollection = async (
+  body: CreateCollectionRequest,
+): Promise<CreateCollectionResponse> => {
+  const response = await authClient.post('/collections', body);
+  return response.data;
+};
+
+export const getCollection = async (): Promise<GetCollectionResponse> => {
+  const response = await authClient.get('/collections');
+  return response.data;
+};
+
+export const getCollectionById = async (
+  id: number,
+): Promise<GetCollectionDetailResponse> => {
+  const response = await authClient.get(`/collections/${id}`);
+  return response.data;
+};
+
+export const updateCollection = async (
+  id: number,
+  body: UpdateCollectionRequest,
+): Promise<void> => {
+  await authClient.patch(`/collections/${id}`, body);
+};
+
+export const addContentsToCollection = async (
+  id: number,
+  body: ModifyContentsRequest,
+): Promise<void> => {
+  await authClient.post(`/collections/${id}/contents`, body);
+};
+
+export const removeContentsFromCollection = async (
+  id: number,
+  body: ModifyContentsRequest,
+): Promise<void> => {
+  await authClient.delete(`/collections/${id}/contents`, {
+    data: body,
+  });
+};
+
+export const deleteCollection = async (id: number): Promise<void> => {
+  await authClient.delete(`/collections/${id}`);
+};

--- a/src/entities/collection/types/collection.type.ts
+++ b/src/entities/collection/types/collection.type.ts
@@ -1,0 +1,42 @@
+import { ContentType } from 'entities/contents/model/types/contents.type';
+
+export interface ContentItem {
+  id: number;
+  contentType: ContentType; // 'movie' | 'tv'
+}
+
+export interface CollectionBase {
+  title: string;
+  description: string;
+  thumbnail: string | null;
+}
+
+export type CreateCollectionRequest = CollectionBase;
+
+export interface CreateCollectionResponse {
+  id: number;
+}
+
+export interface CollectionItem extends CollectionBase {
+  id: number;
+}
+
+export interface GetCollectionResponse {
+  collections: CollectionItem[];
+  count: number;
+}
+
+export interface GetCollectionDetailResponse extends CollectionItem {
+  contents: {
+    id: number;
+    posterPath: string;
+    title: string;
+    contentType: ContentType;
+  }[];
+}
+
+export type UpdateCollectionRequest = Partial<CollectionBase>;
+
+export interface ModifyContentsRequest {
+  contents: ContentItem[];
+}

--- a/src/entities/contents/model/types/contents.type.ts
+++ b/src/entities/contents/model/types/contents.type.ts
@@ -1,10 +1,11 @@
 import { Genre } from 'entities/genre';
 
+export type ContentType = 'movie' | 'tv';
 export interface Contents {
   id: number;
   poster_path: string | null;
   title: string;
-  contentType: 'movie' | 'tv';
+  contentType: ContentType;
 }
 
 export interface ParameterTypes {


### PR DESCRIPTION
Close #30 

## 개요
- #30 collection 관련 api 요청 함수 및 타입 추가 
## 작업사항
- ContenType 분리 (`content.type.ts`)
- `collectionApi.ts`
- `collection.type.ts`
## 주의사항
- `removeContentsFromCollection`의 복수 삭제 요청이 오류가 있을 수 있어 수정이 필요할 수 있음
