### PR TITLE
Feat: collection, genre 관련 테스트 핸들러 구현

### DIFF
--- a/src/entities/genre/types/genre.type.ts
+++ b/src/entities/genre/types/genre.type.ts
@@ -7,5 +7,4 @@ export interface GenreEmoji extends Genre {
 }
 export interface GenreResponse {
   genres: GenreEmoji[];
-  count: number;
 }

--- a/src/shared/mocks/browser.ts
+++ b/src/shared/mocks/browser.ts
@@ -1,7 +1,14 @@
-import { setupWorker } from "msw/browser";
-import { authHandlers } from "./handlers/authHandlers";
-import { userHandlers } from "./handlers/userHandlers";
+import { setupWorker } from 'msw/browser';
+import { authHandlers } from './handlers/authHandlers';
+import { collectionHandlers } from './handlers/collectionHandlers';
+import { genreHandlers } from './handlers/genreHandlers';
+import { userHandlers } from './handlers/userHandlers';
 
-const handlers = [...authHandlers, ...userHandlers];
+const handlers = [
+  ...authHandlers,
+  ...userHandlers,
+  ...collectionHandlers,
+  ...genreHandlers,
+];
 
 export const worker = setupWorker(...handlers);

--- a/src/shared/mocks/handlers/collectionHandlers.ts
+++ b/src/shared/mocks/handlers/collectionHandlers.ts
@@ -1,0 +1,179 @@
+import {
+  CreateCollectionRequest,
+  GetCollectionDetailResponse,
+  ModifyContentsRequest,
+  UpdateCollectionRequest,
+} from 'entities/collection/types/collection.type';
+import { http } from 'msw';
+import { createErrorResponse, createSuccessResponse } from '../utils/response';
+
+const mockCollections: GetCollectionDetailResponse[] = [
+  {
+    id: 1,
+    title: 'Test Collection',
+    description: 'A sample collection',
+    thumbnail: null,
+    contents: [
+      {
+        id: 101,
+        title: 'Mock Movie 1',
+        posterPath: '/images/sample1.jpg',
+        contentType: 'movie',
+      },
+      {
+        id: 102,
+        title: 'Mock TV Show',
+        posterPath: '/images/sample2.jpg',
+        contentType: 'tv',
+      },
+    ],
+  },
+];
+
+let nextId = 2;
+
+export const collectionHandlers = [
+  // 컬렉션 생성
+  http.post('/collections', async ({ request }) => {
+    const body = (await request.json()) as CreateCollectionRequest;
+    const { title, description, thumbnail } = body;
+
+    const newCollection: GetCollectionDetailResponse = {
+      id: nextId++,
+      title,
+      description,
+      thumbnail,
+      contents: [],
+    };
+
+    mockCollections.push(newCollection);
+
+    return createSuccessResponse(
+      '컬렉션이 생성되었습니다.',
+      { id: newCollection.id },
+      201,
+    );
+  }),
+
+  // 컬렉션 리스트 조회
+  http.get('/collections', () => {
+    const summaryList = mockCollections.map(
+      ({ id, title, description, thumbnail }) => ({
+        id,
+        title,
+        description,
+        thumbnail,
+      }),
+    );
+
+    return createSuccessResponse('컬렉션 목록 조회 성공', {
+      collections: summaryList,
+      count: summaryList.length,
+    });
+  }),
+
+  // 컬렉션 상세 조회
+  http.get('/collections/:id', ({ params }) => {
+    const { id } = params;
+
+    const idx = mockCollections.findIndex((c) => c.id === Number(id));
+    if (idx === -1) {
+      return createErrorResponse(
+        404,
+        '컬렉션을 찾을 수 없습니다.',
+        'NOT_FOUND',
+      );
+    }
+
+    return createSuccessResponse('컬렉션 상세 조회 성공', mockCollections[idx]);
+  }),
+
+  // 컬렉션 수정
+  http.patch('/collections/:id', async ({ params, request }) => {
+    const { id } = params;
+    const patchData = (await request.json()) as UpdateCollectionRequest;
+
+    const idx = mockCollections.findIndex((c) => c.id === Number(id));
+    if (idx === -1) {
+      return createErrorResponse(
+        404,
+        '컬렉션을 찾을 수 없습니다.',
+        'NOT_FOUND',
+      );
+    }
+
+    mockCollections[idx] = { ...mockCollections[idx], ...patchData };
+
+    return createSuccessResponse('컬렉션 수정 완료');
+  }),
+
+  // 6. 콘텐츠 추가
+  http.post('/collections/:id/contents', async ({ params, request }) => {
+    const { id } = params;
+    const body = (await request.json()) as ModifyContentsRequest;
+    const { contents } = body;
+
+    const idx = mockCollections.findIndex((c) => c.id === Number(id));
+    if (idx === -1) {
+      return createErrorResponse(
+        404,
+        '컬렉션을 찾을 수 없습니다.',
+        'NOT_FOUND',
+      );
+    }
+
+    const newContents = contents
+      .filter(
+        (item) => !mockCollections[idx].contents.some((c) => c.id === item.id),
+      )
+      .map((item) => ({
+        ...item,
+        title: `Mock Title ${item.id}`,
+        posterPath: `/images/content-${item.id}.jpg`,
+      }));
+
+    mockCollections[idx].contents.push(...newContents);
+
+    return createSuccessResponse('콘텐츠 추가 완료');
+  }),
+
+  // 콘텐츠 제거
+  http.post('/collections/:id/contents', async ({ params, request }) => {
+    const { id } = params;
+    const body = (await request.json()) as ModifyContentsRequest;
+    const { contents } = body;
+
+    const idx = mockCollections.findIndex((c) => c.id === Number(id));
+    if (idx === -1) {
+      return createErrorResponse(
+        404,
+        '컬렉션을 찾을 수 없습니다.',
+        'NOT_FOUND',
+      );
+    }
+
+    const removeIds = new Set(contents.map((c) => c.id));
+    mockCollections[idx].contents = mockCollections[idx].contents.filter(
+      (item) => !removeIds.has(item.id),
+    );
+
+    return createSuccessResponse('콘텐츠 삭제 완료');
+  }),
+
+  // 컬렉션 삭제
+  http.delete('/collections/:id', ({ params }) => {
+    const { id } = params;
+
+    const idx = mockCollections.findIndex((c) => c.id === Number(id));
+    if (idx === -1) {
+      return createErrorResponse(
+        404,
+        '컬렉션을 찾을 수 없습니다.',
+        'NOT_FOUND',
+      );
+    }
+    mockCollections.splice(idx, 1);
+
+    return createSuccessResponse('컬렉션 삭제 완료');
+  }),
+];

--- a/src/shared/mocks/handlers/genreHandlers.ts
+++ b/src/shared/mocks/handlers/genreHandlers.ts
@@ -1,0 +1,58 @@
+import { GenreResponse } from 'entities/genre/types/genre.type';
+import { http } from 'msw';
+import { createSuccessResponse } from '../utils/response';
+
+const mockMovieGenres: GenreResponse['genres'] = [
+  { id: 28, name: '액션', emoji: '🔫' },
+  { id: 12, name: '모험', emoji: '🧭' },
+  { id: 16, name: '애니메이션', emoji: '🎨' },
+  { id: 35, name: '코미디', emoji: '😂' },
+  { id: 80, name: '범죄', emoji: '🕵️‍♂️' },
+  { id: 99, name: '다큐멘터리', emoji: '🎥' },
+  { id: 18, name: '드라마', emoji: '🎭' },
+  { id: 10751, name: '가족', emoji: '👨‍👩‍👧‍👦' },
+  { id: 14, name: '판타지', emoji: '🐉' },
+  { id: 36, name: '역사', emoji: '📜' },
+  { id: 27, name: '공포', emoji: '👻' },
+  { id: 10402, name: '음악', emoji: '🎵' },
+  { id: 9648, name: '미스터리', emoji: '🕵️' },
+  { id: 10749, name: '로맨스', emoji: '💕' },
+  { id: 878, name: 'SF', emoji: '🚀' },
+  { id: 10770, name: 'TV 영화', emoji: '📺' },
+  { id: 53, name: '스릴러', emoji: '😱' },
+  { id: 10752, name: '전쟁', emoji: '⚔️' },
+  { id: 37, name: '서부', emoji: '🤠' },
+];
+
+const mockTvGenres: GenreResponse['genres'] = [
+  { id: 10759, name: '액션 & 어드벤처', emoji: '🗡️' },
+  { id: 16, name: '애니메이션', emoji: '🎨' },
+  { id: 35, name: '코미디', emoji: '😂' },
+  { id: 80, name: '범죄', emoji: '🕵️‍♂️' },
+  { id: 99, name: '다큐멘터리', emoji: '🎥' },
+  { id: 18, name: '드라마', emoji: '🎭' },
+  { id: 10751, name: '가족', emoji: '👨‍👩‍👧‍👦' },
+  { id: 10762, name: '키즈', emoji: '🧒' },
+  { id: 9648, name: '미스터리', emoji: '🕵️' },
+  { id: 10763, name: '뉴스', emoji: '📰' },
+  { id: 10764, name: '리얼리티', emoji: '📸' },
+  { id: 10765, name: 'SF & 판타지', emoji: '🪐' },
+  { id: 10766, name: '막장 드라마', emoji: '💄' },
+  { id: 10767, name: '토크쇼', emoji: '🎙️' },
+  { id: 10768, name: '전쟁 & 정치', emoji: '🪖' },
+  { id: 37, name: '서부', emoji: '🤠' },
+];
+
+export const genreHandlers = [
+  http.get('/genres/movies', () => {
+    return createSuccessResponse('영화 장르 목록 조회 성공', {
+      genres: mockMovieGenres,
+    });
+  }),
+
+  http.get('/genres/tvs', () => {
+    return createSuccessResponse('TV 장르 목록 조회 성공', {
+      genres: mockTvGenres,
+    });
+  }),
+];

--- a/src/shared/mocks/utils/response.ts
+++ b/src/shared/mocks/utils/response.ts
@@ -1,0 +1,31 @@
+import { HttpResponse } from 'msw';
+
+export const createSuccessResponse = (
+  message: string,
+  data: unknown = null,
+  status = 200,
+) =>
+  HttpResponse.json(
+    {
+      statusCode: status,
+      message,
+      ...(data !== null ? { data } : {}),
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+
+export const createErrorResponse = (
+  status: number,
+  message: string,
+  errorCode: string,
+) =>
+  HttpResponse.json(
+    {
+      statusCode: status,
+      message,
+      error: errorCode,
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );


### PR DESCRIPTION
## 📌 개요
- collection, genre 관련 테스트 핸들러 구현
- 공통 응답 유틸 함수 분리
- 장르, 콜렉션 테스트 핸들러 모킹 워커 등록
## 🛠 작업 내용
- `genreHandlers.ts`
- `collectionHandlers.ts`
- `response.ts`
- `browser.ts`
## ⚠️ 주의 사항
- x
## 🔗 관련 이슈
- Close #33 
