### PR TITLE
Feat: 아이콘 정렬해주는 컴포넌트

### DIFF
--- a/src/shared/ui/AlignedIcon/AlignedIcon.tsx
+++ b/src/shared/ui/AlignedIcon/AlignedIcon.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const AlignedIcon = ({ children }: Props) => {
+  return <StyledIcon>{children}</StyledIcon>;
+};
+
+const StyledIcon = styled.span`
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 100%;
+    height: 100%;
+    stroke: ${({ theme }) => theme.color.constantWhite};
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+`;
+
+export default AlignedIcon;

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -14,6 +14,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   fontSize: FontSizeKey;
   scheme: ButtonScheme;
   borderRadius: BorderRadiusKey;
+  disableHoverOverlay?: boolean;
 }
 
 const Button = ({
@@ -22,6 +23,7 @@ const Button = ({
   fontSize,
   scheme,
   borderRadius,
+  disableHoverOverlay = false,
   onClick,
   type = 'button',
 }: Props) => {
@@ -33,6 +35,7 @@ const Button = ({
       borderRadius={borderRadius}
       onClick={onClick}
       type={type}
+      disableHoverOverlay={disableHoverOverlay}
     >
       {children}
     </ButtonStyle>
@@ -41,7 +44,13 @@ const Button = ({
 
 const ButtonStyle = styled.button.withConfig({
   shouldForwardProp: (prop) =>
-    !['scheme', 'buttonSize', 'fontSize', 'borderRadius'].includes(prop),
+    ![
+      'scheme',
+      'buttonSize',
+      'fontSize',
+      'borderRadius',
+      'disableHoverOverlay',
+    ].includes(prop),
 })<Omit<Props, 'children'>>`
   font-size: ${({ theme, buttonSize, fontSize }) => (theme.buttonSize[buttonSize].fontSize ? theme.buttonSize[buttonSize].fontSize : theme.fontSize[fontSize])};
   padding: ${({ theme, buttonSize }) => theme.buttonSize[buttonSize].padding};
@@ -57,7 +66,7 @@ const ButtonStyle = styled.button.withConfig({
       : 'none'};
     line-height: 1;
 
-  ${hoverOverlay}
+  ${({ disableHoverOverlay }) => !disableHoverOverlay && hoverOverlay}
 `;
 
 export default Button;

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,4 +1,6 @@
+export { default as AlignedIcon } from './AlignedIcon/AlignedIcon';
 export { default as Button } from './Button/Button';
 export * from './InputText/InputText';
 export * from './Modal/Modal';
 export * from './ProgressBar/ProgressBar';
+export { default as Title } from './Title/Title';


### PR DESCRIPTION
## 📌 개요
- lucide icon 을 직접 버튼 등에 넣을 경우 특정 방향의 패딩이 더해지는 등 정렬이 안되어 있는 이슈 발생
- 아이콘을 사용하기 전, 정렬해주는 컴포넌트 작성
## 🛠 작업 내용
- AlignedIcon.tsx
- Button.tsx 에 오버레이 해제 props 추가
- 
## ⚠️ 주의 사항
- 메뉴 버튼만  IconButton 으로 extend 한 컴포넌트로 만드려 했으나,
아이콘이 특정 버튼 사이즈나 scheme 에서만 쓰이는것도 아니며, 그렇다고 Button 컴포넌트에 props 로 넘겨주자니 코드가 너무 복잡해지고 오류가 많이 나서 그냥 아이콘을 정렬해주는 역할만 수행하는 컴포넌트를 작성함
## 사용방법
```
        <Button
            buttonSize="menuNarrow"
            fontSize="large"
            scheme="primary"
            borderRadius="medium"
            disableHoverOverlay={true}
          >
            <AlignedIcon>
              <PackageOpen />
            </AlignedIcon>
          </Button>
```
이런 식으로 사용하고자 하는 아이콘을 AlignedIcon 으로 감싸주면 된다.
