### PR TITLE
이미지 경로를 이미지 링크로 바꾸는 유틸 함수 구현 및 적용 

### DIFF
--- a/src/entities/collection/types/collection.type.ts
+++ b/src/entities/collection/types/collection.type.ts
@@ -29,7 +29,7 @@ export interface GetCollectionResponse {
 export interface GetCollectionDetailResponse extends CollectionItem {
   contents: {
     id: number;
-    posterPath: string;
+    posterPath: string | null;
     title: string;
     contentType: ContentType;
   }[];

--- a/src/entities/contents/model/types/contents.type.ts
+++ b/src/entities/contents/model/types/contents.type.ts
@@ -3,7 +3,7 @@ import { Genre } from 'entities/genre';
 export type ContentType = 'movie' | 'tv';
 export interface Contents {
   id: number;
-  poster_path: string | null;
+  posterPath: string | null;
   title: string;
   contentType: ContentType;
 }

--- a/src/entities/contents/model/types/tvs.type.ts
+++ b/src/entities/contents/model/types/tvs.type.ts
@@ -4,5 +4,5 @@ export interface TVs extends ContentsDetail {
   firstAirDate: string;
   lastAirDate: string;
   numberOfSeasons: number;
-  seasons: { id: number; title: string; poster_path: string }[];
+  seasons: { id: number; title: string; posterPath: string }[];
 }

--- a/src/features/contents/ui/ContentItem/ContentItem.tsx
+++ b/src/features/contents/ui/ContentItem/ContentItem.tsx
@@ -26,7 +26,7 @@ const ContentItem = ({ content, isCheckable }: Props) => {
           />
           <div className="img">
             <img
-              src={content.poster_path ?? defaultContentsImage}
+              src={content.posterPath ?? defaultContentsImage}
               alt={content.title}
             />
           </div>
@@ -39,7 +39,7 @@ const ContentItem = ({ content, isCheckable }: Props) => {
           <div className="contents-wrapper">
             <div className="img">
               <img
-                src={content.poster_path ?? defaultContentsImage}
+                src={content.posterPath ?? defaultContentsImage}
                 alt={content.title}
               />
             </div>

--- a/src/features/contents/ui/ContentItem/ContentItem.tsx
+++ b/src/features/contents/ui/ContentItem/ContentItem.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import defaultContentsImage from 'shared/assets/images/default-contents-image.png';
 import { hoverOverlay } from 'shared/styles/hoverOverlay';
+import { getImageUrl } from 'shared/utils/getImageUrl';
 import styled from 'styled-components';
 import { CONTENT_ITEM_HEIGHT, CONTENT_ITEM_WIDTH } from '../constants';
 
@@ -26,7 +27,11 @@ const ContentItem = ({ content, isCheckable }: Props) => {
           />
           <div className="img">
             <img
-              src={content.posterPath ?? defaultContentsImage}
+              src={
+                content.posterPath
+                  ? getImageUrl(content.posterPath)
+                  : defaultContentsImage
+              }
               alt={content.title}
             />
           </div>
@@ -39,7 +44,11 @@ const ContentItem = ({ content, isCheckable }: Props) => {
           <div className="contents-wrapper">
             <div className="img">
               <img
-                src={content.posterPath ?? defaultContentsImage}
+                src={
+                  content.posterPath
+                    ? getImageUrl(content.posterPath)
+                    : defaultContentsImage
+                }
                 alt={content.title}
               />
             </div>
@@ -123,6 +132,9 @@ const ContentItemStyle = styled.div<{
       padding: 0 0 2px 4px;
       margin: 0;           /* ✅ 추가: 텍스트 마진 제거 */
       line-height: 1.2;    /* ✅ 필요 시 조정 */
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 `;

--- a/src/features/contents/ui/ContentsList/ContentsList.stye.ts
+++ b/src/features/contents/ui/ContentsList/ContentsList.stye.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { CONTENT_ITEM_GAP, CONTENT_LIST_WIDTH } from '../constants';
 
 export const Wrapper = styled.section`
-  margin-bottom: 24px;
+  margin-top: 24px;
   width: ${CONTENT_LIST_WIDTH}px;
 `;
 

--- a/src/shared/constants/image.ts
+++ b/src/shared/constants/image.ts
@@ -1,0 +1,11 @@
+export enum ImageSize {
+  W92 = 'w92',
+  W154 = 'w154',
+  W185 = 'w185',
+  W300 = 'w300',
+  W500 = 'w500',
+  W780 = 'w780',
+  ORIGINAL = 'original',
+}
+
+export const DEFAULT_IMAGE_SIZE = ImageSize.W300;

--- a/src/shared/mocks/handlers/contentsHandlers.ts
+++ b/src/shared/mocks/handlers/contentsHandlers.ts
@@ -17,26 +17,26 @@ export const mockGenres: Genre[] = [
 export const mockContents: Contents[] = [
   {
     id: 1,
-    poster_path: '/images/poster1.jpg',
+    posterPath: '/images/poster1.jpg',
     title: 'Inception',
     contentType: 'movie',
   },
 
   {
     id: 2,
-    poster_path: '/images/poster2.jpg',
+    posterPath: '/images/poster2.jpg',
     title: 'Interstellar',
     contentType: 'movie',
   },
   {
     id: 3,
-    poster_path: '/images/poster3.jpg',
+    posterPath: '/images/poster3.jpg',
     title: 'Breaking Bad',
     contentType: 'tv',
   },
   {
     id: 4,
-    poster_path: '/images/poster4.jpg',
+    posterPath: '/images/poster4.jpg',
     title: 'Stranger Things',
     contentType: 'tv',
   },
@@ -56,7 +56,7 @@ export const mockContentsResponse: ContentsResponse = {
 export const mockMovies: Movie[] = [
   {
     id: 1,
-    poster_path: '/images/movie1.jpg',
+    posterPath: '/images/movie1.jpg',
     title: 'Mock Movie 1',
     contentType: 'movie',
     originalLanguage: 'en',
@@ -71,7 +71,7 @@ export const mockMovies: Movie[] = [
   },
   {
     id: 2,
-    poster_path: '/images/movie2.jpg',
+    posterPath: '/images/movie2.jpg',
     title: 'Mock Movie 2',
     contentType: 'movie',
     originalLanguage: 'ko',
@@ -89,7 +89,7 @@ export const mockMovies: Movie[] = [
 export const mockTVs: TVs[] = [
   {
     id: 101,
-    poster_path: '/images/tv1.jpg',
+    posterPath: '/images/tv1.jpg',
     title: 'Mock TV Series 1',
     contentType: 'tv',
     originalLanguage: 'ko',
@@ -103,8 +103,8 @@ export const mockTVs: TVs[] = [
     lastAirDate: '2023-01-01',
     numberOfSeasons: 2,
     seasons: [
-      { id: 1, title: 'Season 1', poster_path: '/images/tv1_season1.jpg' },
-      { id: 2, title: 'Season 2', poster_path: '/images/tv1_season2.jpg' },
+      { id: 1, title: 'Season 1', posterPath: '/images/tv1_season1.jpg' },
+      { id: 2, title: 'Season 2', posterPath: '/images/tv1_season2.jpg' },
     ],
   },
 ];

--- a/src/shared/utils/getImageUrl.ts
+++ b/src/shared/utils/getImageUrl.ts
@@ -1,0 +1,9 @@
+import { DEFAULT_IMAGE_SIZE, ImageSize } from 'shared/constants/image';
+
+export const getImageUrl = (
+  path: string | null,
+  size: ImageSize = DEFAULT_IMAGE_SIZE,
+): string | undefined => {
+  if (!path) return undefined;
+  return `https://image.tmdb.org/t/p/${size}${path}`;
+};

--- a/src/widgets/Footer.tsx
+++ b/src/widgets/Footer.tsx
@@ -66,7 +66,8 @@ export default Footer;
 const FooterWrapper = styled.footer`
   background: ${({ theme }) => theme.color.subBackground};
   padding: 40px 0 40px 40px;
-   display: flex;
+  display: flex;
+  margin-top: 90px;
 `;
 
 const FooterColumnLogo = styled.div`


### PR DESCRIPTION
## 📌 개요
- 이미지 경로를 이미지 링크로 바꾸는 유틸 함수 구현 및 적용 

## 🛠 작업 내용
- `getImageUrl.ts` 이미지 링크 변환 함수
- `image.ts` 이미지 크기 enum 으로 정리
- `poster_path` -> `posterPath`로 네이밍 변경
- 기타 스타일링 변경 (마진 변경)
## ⚠️ 주의 사항
- x
## 🔗 관련 이슈
- Close #104 
