### PR TITLE
TV, Movie 장르 페이지 구현

### DIFF
--- a/src/features/genre/style/GenreSelectPage.style.ts
+++ b/src/features/genre/style/GenreSelectPage.style.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const GenreButton = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2.5rem; 
+  margin-top: 3rem;
+`;
+
+export const GenreSelectForm = styled.div`
+  display: flex;
+  flex-direction:column;
+  min-height: 75vh;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 2rem;
+  justify-content: flex-end;
+  margin-top: auto; 
+  `;
+
+export const GenreContainer = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0 7vw;
+`;

--- a/src/features/genre/ui/GenreSelector.tsx
+++ b/src/features/genre/ui/GenreSelector.tsx
@@ -1,0 +1,54 @@
+import { ContentType } from 'entities/contents/model/types/contents.type';
+import { Button } from 'shared/ui';
+import Loading from 'shared/ui/Loading/Loading';
+import { useGetMovieGenres } from '../hooks/useGetMovieGenres';
+import { useGetTVSeriesGenres } from '../hooks/useGetTVSeriesGenres';
+import { GenreButton } from '../style/GenreSelectPage.style';
+
+interface Props {
+  type: ContentType;
+  selectedIds: number[];
+  onSelect: (updated: number[]) => void;
+}
+
+export const GenreSelector = ({ type, selectedIds, onSelect }: Props) => {
+  const movieGenresQuery = useGetMovieGenres();
+  const tvGenresQuery = useGetTVSeriesGenres();
+
+  const genres =
+    type === 'movie'
+      ? movieGenresQuery.data?.genres
+      : tvGenresQuery.data?.genres;
+
+  const isLoading =
+    type === 'movie' ? movieGenresQuery.isLoading : tvGenresQuery.isLoading;
+
+  if (isLoading) return <Loading />;
+
+  const toggleGenre = (id: number) => {
+    const updated = selectedIds.includes(id)
+      ? selectedIds.filter((g) => g !== id)
+      : [...selectedIds, id];
+    onSelect(updated);
+  };
+
+  return (
+    <GenreButton>
+      {genres?.map((genre) => {
+        const isSelected = selectedIds.includes(genre.id);
+        return (
+          <Button
+            key={genre.id}
+            scheme={isSelected ? 'genreActive' : 'genre'}
+            buttonSize="genre"
+            fontSize="small"
+            borderRadius="round"
+            onClick={() => toggleGenre(genre.id)}
+          >
+            {genre.name} {genre.emoji}
+          </Button>
+        );
+      })}
+    </GenreButton>
+  );
+};

--- a/src/features/genre/ui/MovieGenreSelectForm.tsx
+++ b/src/features/genre/ui/MovieGenreSelectForm.tsx
@@ -1,0 +1,75 @@
+// MovieGenreForm.tsx
+
+import { useUserPreference } from 'features/user/preference/hooks/useGetUserPreference';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from 'shared/ui';
+import { toast } from 'sonner';
+import { ButtonWrapper, GenreSelectForm } from '../style/GenreSelectPage.style';
+import { GenreSelector } from './GenreSelector';
+
+export const MovieGenreSelectForm = () => {
+  const [selectedGenres, setSelectedGenres] = useState<number[]>(() => {
+    const saved = sessionStorage.getItem('selectedMovieGenres');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  const location = useLocation();
+  const navigate = useNavigate();
+  const from = location.state?.from;
+
+  const { data: preferenceData } = useUserPreference();
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('selectedMovieGenres');
+    const hasSaved = saved && JSON.parse(saved).length > 0;
+    if (!preferenceData || hasSaved) return;
+
+    const genres = preferenceData.movies.genres.map((g) => g.id);
+    setSelectedGenres(genres);
+    sessionStorage.setItem('selectedMovieGenres', JSON.stringify(genres));
+  }, [preferenceData]);
+
+  useEffect(() => {
+    sessionStorage.setItem(
+      'selectedMovieGenres',
+      JSON.stringify(selectedGenres),
+    );
+  }, [selectedGenres]);
+
+  const handleNext = () => {
+    if (selectedGenres.length === 0) {
+      toast.error('영화 장르를 최소 1개 이상 선택해주세요.');
+      return;
+    }
+
+    navigate('/genre/tv', {
+      state: {
+        from,
+      },
+    });
+  };
+
+  return (
+    <GenreSelectForm>
+      <GenreSelector
+        type="movie"
+        selectedIds={selectedGenres}
+        onSelect={setSelectedGenres}
+      />
+
+      <ButtonWrapper>
+        <Button
+          onClick={handleNext}
+          fontSize="small"
+          disabled={selectedGenres.length === 0}
+          scheme="primary"
+          buttonSize="medium"
+          borderRadius="round"
+        >
+          다음
+        </Button>
+      </ButtonWrapper>
+    </GenreSelectForm>
+  );
+};

--- a/src/features/genre/ui/TVGenreSelectForm.tsx
+++ b/src/features/genre/ui/TVGenreSelectForm.tsx
@@ -1,0 +1,107 @@
+// TvGenreForm.tsx
+
+import { useUserPreference } from 'features/user/preference/hooks/useGetUserPreference';
+import { useUpdateUserPreference } from 'features/user/preference/hooks/useUpdateUserPreference';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from 'shared/ui';
+import { toast } from 'sonner';
+import { ButtonWrapper, GenreSelectForm } from '../style/GenreSelectPage.style';
+import { GenreSelector } from './GenreSelector';
+
+export const TvGenreSelectForm = () => {
+  const [selectedGenres, setSelectedGenres] = useState<number[]>(() => {
+    const saved = sessionStorage.getItem('selectedTvGenres');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  const { mutate, isPending } = useUpdateUserPreference();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const from = location.state?.from;
+
+  const { data: preferenceData } = useUserPreference();
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('selectedMovieGenres');
+    const movieGenres = saved ? JSON.parse(saved) : [];
+
+    if (movieGenres.length === 0) {
+      toast.error('영화 장르 선택 후 TV 장르를 진행해주세요.');
+      navigate('/genre/movie', { replace: true });
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('selectedTvGenres');
+    const hasSaved = saved && JSON.parse(saved).length > 0;
+    if (!preferenceData || hasSaved) return;
+
+    const genres = preferenceData.tvs.genres.map((g) => g.id);
+    setSelectedGenres(genres);
+    sessionStorage.setItem('selectedTvGenres', JSON.stringify(genres));
+  }, [preferenceData]);
+
+  useEffect(() => {
+    sessionStorage.setItem('selectedTvGenres', JSON.stringify(selectedGenres));
+  }, [selectedGenres]);
+
+  const handleSubmit = () => {
+    const movieGenreIds = JSON.parse(
+      sessionStorage.getItem('selectedMovieGenres') || '[]',
+    );
+
+    if (selectedGenres.length === 0) {
+      toast.error('TV 시리즈 장르를 최소 1개 이상 선택해주세요.');
+      return;
+    }
+
+    mutate(
+      {
+        movie: { genreIds: movieGenreIds },
+        tv: { genreIds: selectedGenres },
+      },
+      {
+        onSuccess: () => {
+          sessionStorage.removeItem('selectedMovieGenres');
+          sessionStorage.removeItem('selectedTvGenres');
+
+          const redirectTo = from === '/login' ? '/' : '/mypage';
+          navigate(redirectTo, { replace: true });
+        },
+      },
+    );
+  };
+
+  return (
+    <GenreSelectForm>
+      <GenreSelector
+        type="tv"
+        selectedIds={selectedGenres}
+        onSelect={setSelectedGenres}
+      />
+
+      <ButtonWrapper>
+        <Button
+          onClick={() => navigate('/genre/movie', { state: { from } })}
+          fontSize="small"
+          scheme="secondary"
+          buttonSize="medium"
+          borderRadius="round"
+        >
+          이전
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          fontSize="small"
+          disabled={isPending || selectedGenres.length === 0}
+          scheme="primary"
+          buttonSize="medium"
+          borderRadius="round"
+        >
+          제출
+        </Button>
+      </ButtonWrapper>
+    </GenreSelectForm>
+  );
+};

--- a/src/pages/preference/MovieGenreSelectPage.tsx
+++ b/src/pages/preference/MovieGenreSelectPage.tsx
@@ -1,3 +1,15 @@
+import { GenreContainer } from 'features/genre/style/GenreSelectPage.style';
+import { MovieGenreSelectForm } from 'features/genre/ui/MovieGenreSelectForm';
+import { ProgressBar, Title } from 'shared/ui';
+
 export default function MovieGenreSelectPage() {
-  return <div>MovieGenreSelectPage</div>;
+  return (
+    <GenreContainer>
+      <div>
+        <ProgressBar from={0} to={50} label={'영화 취향 분석 중... 🎬'} />
+        <Title as="h1">평소 관심 있는 영화 장르는 무엇인가요?</Title>
+        <MovieGenreSelectForm />
+      </div>
+    </GenreContainer>
+  );
 }

--- a/src/pages/preference/TVGenreSelectPage.tsx
+++ b/src/pages/preference/TVGenreSelectPage.tsx
@@ -1,3 +1,19 @@
+import { GenreContainer } from 'features/genre/style/GenreSelectPage.style';
+import { TvGenreSelectForm } from 'features/genre/ui/TVGenreSelectForm';
+import { ProgressBar, Title } from 'shared/ui';
+
 export default function TVGenreSelectPage() {
-  return <div>TVGenreSelectPage</div>;
+  return (
+    <GenreContainer>
+      <div>
+        <ProgressBar
+          from={50}
+          to={100}
+          label={'TV 시리즈 취향 분석 중... 📺'}
+        />
+        <Title as="h1">평소 관심 있는 TV 시리즈 장르는 무엇인가요?</Title>
+        <TvGenreSelectForm />
+      </div>
+    </GenreContainer>
+  );
 }

--- a/src/shared/mocks/handlers/preferenceHandler.ts
+++ b/src/shared/mocks/handlers/preferenceHandler.ts
@@ -5,81 +5,20 @@ import { createErrorResponse, createSuccessResponse } from '../utils/response';
 const userPreference = {
   movies: {
     genres: [
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
+      { id: 28, name: '액션', emoji: '🔫' },
+      { id: 12, name: '모험', emoji: '🧭' },
     ],
     count: 8,
   },
   tvs: {
     genres: [
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
-      {
-        id: 20,
-        name: '드라마',
-        emoji: '🎭',
-      },
+      { id: 10759, name: '액션 & 어드벤처', emoji: '🗡️' },
+      { id: 16, name: '애니메이션', emoji: '🎨' },
+      { id: 35, name: '코미디', emoji: '😂' },
+      { id: 80, name: '범죄', emoji: '🕵️‍♂️' },
+      { id: 99, name: '다큐멘터리', emoji: '🎥' },
+      { id: 18, name: '드라마', emoji: '🎭' },
+      { id: 10751, name: '가족', emoji: '👨‍👩‍👧‍👦' },
     ],
     count: 6,
   },
@@ -88,46 +27,8 @@ const userPreference = {
 const _emptyPreference = {
   movies: {
     genres: [
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
-      {
-        id: 1,
-        name: '액션',
-        emoji: '🔥',
-      },
-      {
-        id: 2,
-        name: '모험',
-        emoji: '🗺️',
-      },
+      { id: 28, name: '액션', emoji: '🔫' },
+      { id: 12, name: '모험', emoji: '🧭' },
     ],
     count: 8,
   },

--- a/src/shared/ui/ProgressBar/ProgressBar.style.ts
+++ b/src/shared/ui/ProgressBar/ProgressBar.style.ts
@@ -8,7 +8,8 @@ export const Wrapper = styled.div`
 export const LabelRow = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 8px;
+  margin-top: 8px;
+  font-size: ${({ theme }) => theme.fontSize.xsmall};
   span {
     color: ${({ theme }) => theme.color.thirdText};
   }

--- a/src/shared/ui/ProgressBar/ProgressBar.tsx
+++ b/src/shared/ui/ProgressBar/ProgressBar.tsx
@@ -25,12 +25,12 @@ export const ProgressBar = ({ from, to, label }: ProgressBarProps) => {
 
   return (
     <Wrapper>
-      <LabelRow>
-        <span>{label}</span>
-      </LabelRow>
       <StyledProgress value={current} max={100}>
         <Indicator width={current} />
       </StyledProgress>
+      <LabelRow>
+        <span>{label}</span>
+      </LabelRow>
     </Wrapper>
   );
 };


### PR DESCRIPTION
## 📌 개요
- #100 
## 🛠 작업 내용
- 선호 장르 mock 데이터 실제 장르 값으로 변경
- location에서 받는 상태값 from을 통해 navigate (로그인 -> 메인, 마이페이지 -> 마이페이지)
- 장르 최소 1개 이상 선택하도록 함
- 선택한 장르 session으로 저장하여 뒤로가기나 이전 버튼 클릭 시에 데이터 유실하지 않도록 함
- movie 세션 값 없이 tv 진입 시( movie 페이지 거치지 않은 비정상 루트)에 movie 페이지로 강제 이동
- ProgressBar label(진행 설명글) 위치 및 크기 조정
## ⚠️ 주의 사항
- movie 세션 값 없이 tv 진입 시( movie 페이지 거치지 않은 비정상 루트)에 기존에 movie 장르를 선택해둔 유저의 경우  movie 세션이 없어도 기존에 사용자가 선택해둔 movie 장르를 불러와 배열을 채우고 tv만 선택해도 제출을 가능하게 할지 미정 (현재는 movie 세션값이 없으면 누구든 movie로 이동)
## 🔗 관련 이슈
- Close #100 
## 캡쳐화면
<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/bf8dcb99-691a-45a8-9451-6b49d4e2b8a9" />
<img width="1917" height="904" alt="image" src="https://github.com/user-attachments/assets/de9674e5-f9d1-4b97-bc71-c5466607e600" />

