### PR TITLE
Feat/ 기능 별 에러 핸들링 작성 및 기타 오류 수정

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,14 +9,14 @@ import { Routers } from './Routers';
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <ThemeProviders>
+      <ThemeProviders>
+        <AuthProvider>
           <BrowserRouter>
             <ScrollToTop />
             <Routers />
           </BrowserRouter>
-        </ThemeProviders>
-      </AuthProvider>
+        </AuthProvider>
+      </ThemeProviders>
     </QueryClientProvider>
   );
 }

--- a/src/app/AuthProvider.tsx
+++ b/src/app/AuthProvider.tsx
@@ -1,12 +1,15 @@
 import { useRefreshToken } from 'features/auth/refreshToken/hooks/useRefreshToken';
 import { useEffect } from 'react';
+import Loading from 'shared/ui/Loading/Loading';
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const { refresh } = useRefreshToken();
+  const { refresh, isPending } = useRefreshToken();
 
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  if (isPending) return <Loading />;
 
   return <>{children}</>;
 };

--- a/src/features/auth/login/model/hooks/useLocalLogin.ts
+++ b/src/features/auth/login/model/hooks/useLocalLogin.ts
@@ -5,22 +5,29 @@ import {
   LoginRequestType,
   LoginResponse,
 } from 'entities/auth/model/types/auth.type';
-import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
+import {
+  CustomErrorResponse,
+  CustomValidationErrorResponse,
+} from 'shared/types/CustomErrorResponse';
 import { useAfterLogin } from './useAfterLogin';
 
 export const useLocalLogin = (option?: {
-  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+  onSuccess?: (data: LoginResponse) => void;
+  onError?: (
+    error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+  ) => void;
 }) => {
   const afterLogin = useAfterLogin();
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     LoginResponse,
-    AxiosError<CustomErrorResponse>,
+    AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
     LoginRequestType
   >({
     mutationFn: login,
     onSuccess: (res) => {
       // 로그인 성공 후 처리 로직
       afterLogin(res); // 로그인 후 처리 함수 호출
+      option?.onSuccess?.(res); // 컴포넌트에서 후처리 로직 추가 가능
     },
     onError: (err) => {
       option?.onError?.(err);

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -5,7 +5,9 @@ import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import googleLogo from 'shared/assets/images/google-logo-icon.png';
 import kakaoLogo from 'shared/assets/images/kakao-logo-icon.png';
+import { isValidationError } from 'shared/types/CustomErrorResponse';
 import { Button, IconPreset, InputText, Title } from 'shared/ui';
+import { setErrorFromServer } from 'shared/validation/setErrorFromServer';
 import { toast } from 'sonner';
 import { useLocalLogin } from '../model/hooks/useLocalLogin';
 import { useOAUthLogin } from '../model/hooks/useOAuthLogin';
@@ -17,6 +19,7 @@ const LoginForm = () => {
     register,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
   });
@@ -25,8 +28,14 @@ const LoginForm = () => {
   const { mutate, isPending } = useLocalLogin({
     onError: (error) => {
       console.log('로그인 실패:', error.response?.data);
-      const message = error.response?.data?.message || '로그인에 실패했습니다.';
-      toast.error(message);
+      if (isValidationError(error)) {
+        // 백엔드에서 받은 유효성 에러를 폼에 띄움
+        setErrorFromServer<LoginFormValues>(error, setError);
+      } else {
+        // 일반적인 에러 처리
+        const message = error.response?.data?.message || '로그에 실패했습니다.';
+        toast.error(message as string);
+      }
     },
   });
   const { loginWithGoogle, loginWithKakao } = useOAUthLogin();

--- a/src/features/auth/logout/hooks/useLogout.ts
+++ b/src/features/auth/logout/hooks/useLogout.ts
@@ -1,12 +1,21 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { logout } from 'entities/auth/model';
 import { useAuthStore } from 'entities/auth/model/store/authStore';
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from 'shared/lib/queryClient';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useLogout = () => {
+export const useLogout = (option?: {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+}) => {
   const navigate = useNavigate();
-  const { mutate, isPending, isSuccess, isError, error } = useMutation({
+  const { mutate, isPending, isSuccess, isError, error } = useMutation<
+    void,
+    AxiosError<CustomErrorResponse>,
+    void
+  >({
     mutationFn: logout,
     onSuccess: () => {
       // 1. 클라이언트 상태 초기화 (예: 토큰 삭제)
@@ -16,9 +25,11 @@ export const useLogout = () => {
       // 3. 캐시 초기화
       queryClient.clear();
       console.log('Successfully logged out');
+      option?.onSuccess?.();
     },
     onError: (error) => {
       console.error('Logout failed', error);
+      option?.onError?.(error);
     },
   });
   return {

--- a/src/features/auth/refreshToken/hooks/useRefreshToken.ts
+++ b/src/features/auth/refreshToken/hooks/useRefreshToken.ts
@@ -1,16 +1,21 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { refreshToken } from 'entities/auth/model/services/authApi';
 import { useAuthStore } from 'entities/auth/model/store/authStore';
 import { RefereshTokenResponse } from 'entities/auth/model/types/auth.type';
 import { useCallback } from 'react';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useRefreshToken = () => {
+export const useRefreshToken = (option?: {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+}) => {
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const resetAccessToken = useAuthStore((state) => state.resetAccessToken);
 
   const { mutateAsync, isPending, isError, error, isSuccess } = useMutation<
     RefereshTokenResponse,
-    Error,
+    AxiosError<CustomErrorResponse>,
     void
   >({
     mutationFn: refreshToken,
@@ -20,12 +25,20 @@ export const useRefreshToken = () => {
     try {
       const res = await mutateAsync();
       setAccessToken(res.accessToken);
+      option?.onSuccess?.();
       return res.accessToken;
     } catch (err) {
       resetAccessToken();
+      option?.onError?.(err as AxiosError<CustomErrorResponse>);
       throw err;
     }
-  }, [mutateAsync, setAccessToken, resetAccessToken]); //  의존성 정확히 명시
+  }, [
+    mutateAsync,
+    setAccessToken,
+    resetAccessToken,
+    option?.onSuccess,
+    option?.onError,
+  ]); //  의존성 정확히 명시
 
   return { refresh, isPending, isError, isSuccess, error };
 };

--- a/src/features/auth/signup/hooks/useSignup.ts
+++ b/src/features/auth/signup/hooks/useSignup.ts
@@ -2,15 +2,20 @@ import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { signup } from 'entities/auth/model';
 import { SignupRequestType } from 'entities/auth/model/types/auth.type';
-import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
+import {
+  CustomErrorResponse,
+  CustomValidationErrorResponse,
+} from 'shared/types/CustomErrorResponse';
 
 export const useSignup = (option?: {
   onSuccess?: () => void;
-  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+  onError?: (
+    error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+  ) => void;
 }) => {
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     void,
-    AxiosError<CustomErrorResponse>,
+    AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
     SignupRequestType
   >({
     mutationFn: signup,

--- a/src/features/auth/signup/ui/SignupForm.tsx
+++ b/src/features/auth/signup/ui/SignupForm.tsx
@@ -4,7 +4,9 @@ import { PackageOpen } from 'lucide-react';
 
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
+import { isValidationError } from 'shared/types/CustomErrorResponse';
 import { Button, IconPreset, InputText, Title } from 'shared/ui';
+import { setErrorFromServer } from 'shared/validation/setErrorFromServer';
 import { toast } from 'sonner';
 import { useSignup } from '../hooks/useSignup';
 import { SignupFormValues, signupSchema } from '../validation/signupSchema';
@@ -14,6 +16,7 @@ const SignupForm = () => {
     register,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<SignupFormValues>({
     resolver: zodResolver(signupSchema),
   });
@@ -25,9 +28,16 @@ const SignupForm = () => {
     },
     onError: (error) => {
       console.log('회원가입 실패:', error.response?.data);
-      const message =
-        error.response?.data?.message || '회원가입에 실패했습니다.';
-      toast.error(message);
+
+      if (isValidationError(error)) {
+        // 백엔드에서 받은 유효성 에러를 폼에 띄움
+        setErrorFromServer<SignupFormValues>(error, setError);
+      } else {
+        // 일반적인 에러 처리
+        const message =
+          error.response?.data?.message || '회원가입에 실패했습니다.';
+        toast.error(message as string);
+      }
     },
   });
 

--- a/src/features/auth/updatePassword/hooks/useUpdatePassword.ts
+++ b/src/features/auth/updatePassword/hooks/useUpdatePassword.ts
@@ -1,21 +1,33 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { UpdatePasswordRequestType, updatePassword } from 'entities/auth/model';
 import { useNavigate } from 'react-router-dom';
+import {
+  CustomErrorResponse,
+  CustomValidationErrorResponse,
+} from 'shared/types/CustomErrorResponse';
 
-export const useUpdatePassword = () => {
+export const useUpdatePassword = (option?: {
+  onSuccess?: () => void;
+  onError?: (
+    error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+  ) => void;
+}) => {
   const navigate = useNavigate();
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     void,
-    unknown,
+    AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
     UpdatePasswordRequestType
   >({
     mutationFn: updatePassword,
     onSuccess: () => {
       console.log('비밀번호가 성공적으로 변경되었습니다.');
       navigate('/mypage', { replace: true }); // 마이페이지로 리다이렉트
+      option?.onSuccess?.();
     },
     onError: (error) => {
       console.error('비밀번호 변경 실패:', error);
+      option?.onError?.(error);
     },
   });
   return {

--- a/src/features/auth/updatePassword/ui/UpdatePasswordModal.tsx
+++ b/src/features/auth/updatePassword/ui/UpdatePasswordModal.tsx
@@ -1,6 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { isValidationError } from 'shared/types/CustomErrorResponse';
 import { InputText, Modal } from 'shared/ui';
+import { setErrorFromServer } from 'shared/validation/setErrorFromServer';
+import { toast } from 'sonner';
 import styled from 'styled-components';
 import { useUpdatePassword } from '../hooks/useUpdatePassword';
 import {
@@ -18,10 +21,28 @@ const UpdatePasswordModal = ({ open, onClose }: UpdatePasswordModalProps) => {
     register,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<UpdatePasswordFormValues>({
     resolver: zodResolver(updatePasswordSchema),
   });
-  const { mutate } = useUpdatePassword();
+  const { mutate } = useUpdatePassword({
+    onSuccess: () => {
+      toast.success('비밀번호가 변경되었습니다!');
+    },
+    onError: (error) => {
+      console.error('비밀번호 변경 실패:', error.response?.data);
+
+      if (isValidationError(error)) {
+        // 백엔드에서 받은 유효성 에러를 폼에 띄움
+        setErrorFromServer<UpdatePasswordFormValues>(error, setError);
+      } else {
+        // 일반적인 에러 처리
+        const message =
+          error.response?.data?.message || '비밀번호를 변경하지 못했어요.';
+        toast.error(message as string);
+      }
+    },
+  });
 
   const onSubmit = (data: UpdatePasswordFormValues) => {
     console.log('제출된 값:', data);

--- a/src/features/contents/ui/ContentsList/ContentsInfiniteList.tsx
+++ b/src/features/contents/ui/ContentsList/ContentsInfiniteList.tsx
@@ -55,7 +55,7 @@ const ContentsInfiniteList = ({
 
       <Grid>
         {data?.pages.map((page) =>
-          page.contents.map((content) => (
+          page.contents?.map((content) => (
             <ContentItemView key={content.id} content={content} />
           )),
         )}

--- a/src/features/contents/ui/ListTab/tabMap.ts
+++ b/src/features/contents/ui/ListTab/tabMap.ts
@@ -8,7 +8,7 @@ export const tabMap: Record<ContentType, TabOption[]> = {
       id: 'byGenre',
       label: '추천 영화',
       queryKey: ['movies', 'byGenre'],
-      queryFn: null as any, // 장르별 조회 밖에서 고차함수로 생
+      queryFn: null as any, // 장르별 조회 밖에서 고차함수로 생성
     },
     {
       id: 'popular',

--- a/src/features/user/preference/hooks/useGetUserContentsPreference.ts
+++ b/src/features/user/preference/hooks/useGetUserContentsPreference.ts
@@ -1,21 +1,43 @@
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { ContentType } from 'entities/contents/model/types/contents.type';
 import {
   fetchMoviePreference,
   fetchTVPreference,
   UserContentsPreference,
 } from 'entities/user/model';
+import { useEffect } from 'react';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
 const fetchMap: Record<ContentType, () => Promise<UserContentsPreference>> = {
   movie: fetchMoviePreference,
   tv: fetchTVPreference,
 };
 
-export const useUserContentsPreference = (type: ContentType) => {
-  const { data, isLoading, isError, error } = useQuery<UserContentsPreference>({
+export const useUserContentsPreference = (
+  type: ContentType,
+  option?: {
+    onSuccess?: (data: UserContentsPreference) => void;
+    onError?: (error: AxiosError<CustomErrorResponse>) => void;
+  },
+) => {
+  const { data, isLoading, isError, error } = useQuery<
+    UserContentsPreference,
+    AxiosError<CustomErrorResponse>
+  >({
     queryKey: ['preference', type],
     queryFn: fetchMap[type],
   });
+
+  // 후처리 함수 실행
+  useEffect(() => {
+    if (data) option?.onSuccess?.(data);
+  }, [data, option?.onSuccess]);
+
+  useEffect(() => {
+    if (error) option?.onError?.(error);
+  }, [error, option?.onError]);
+
   return {
     data,
     isLoading,

--- a/src/features/user/preference/hooks/useGetUserPreference.ts
+++ b/src/features/user/preference/hooks/useGetUserPreference.ts
@@ -1,11 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { fetchPreference, UserPreference } from 'entities/user/model';
+import { useEffect } from 'react';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useUserPreference = () => {
-  const { data, isLoading, isError, error } = useQuery<UserPreference>({
+export const useUserPreference = (option?: {
+  onSuccess?: (data: UserPreference) => void;
+  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+}) => {
+  const { data, isLoading, isError, error } = useQuery<
+    UserPreference,
+    AxiosError<CustomErrorResponse>
+  >({
     queryKey: ['preference'],
     queryFn: fetchPreference,
   });
+
+  // 후처리 함수 실행
+  useEffect(() => {
+    if (data) option?.onSuccess?.(data);
+  }, [data, option?.onSuccess]);
+
+  useEffect(() => {
+    if (error) option?.onError?.(error);
+  }, [error, option?.onError]);
+
   return {
     data,
     isLoading,

--- a/src/features/user/preference/hooks/useUpdateUserPreference.ts
+++ b/src/features/user/preference/hooks/useUpdateUserPreference.ts
@@ -1,23 +1,30 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import {
   UserPreferenceUpdateType,
   updatePreference,
 } from 'entities/user/model';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useUpdateUserPreference = () => {
+export const useUpdateUserPreference = (option?: {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+}) => {
   const queryClient = useQueryClient();
 
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     void,
-    unknown,
+    AxiosError<CustomErrorResponse>,
     UserPreferenceUpdateType
   >({
     mutationFn: updatePreference,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['preference'] });
+      option?.onSuccess?.();
     },
     onError: (error) => {
       console.error('취향 업데이트 실패:', error);
+      option?.onError?.(error);
     },
   });
 

--- a/src/features/user/preference/ui/UserPreferenceList.tsx
+++ b/src/features/user/preference/ui/UserPreferenceList.tsx
@@ -6,65 +6,63 @@ import { useUserPreference } from '../hooks/useGetUserPreference';
 
 const UserPreferenceList = () => {
   const { data, isLoading } = useUserPreference();
+
   if (isLoading) return <Loading />;
   if (!data) return <ErrorBox errorMessage="취향을 불러오지 못했습니다" />;
+
   const { movie, tv } = data;
+
+  if (movie.count === 0 && tv.count === 0) {
+    return (
+      <UserPreferenceListStyle>
+        <Empty text="취향을 설정하지 않았습니다." height="50vh" />
+      </UserPreferenceListStyle>
+    );
+  }
+
   return (
     <UserPreferenceListStyle>
       <Title size="small" color="thirdText" className="header">
         영화
       </Title>
       <div className="genre-buttons">
-        {movie.genres.length === 0 ? (
-          <div className="empty-wrapper">
-            <Empty text="영화 취향이 없습니다" />
-          </div>
-        ) : (
-          movie.genres.map((genre) => (
-            <Button
-              buttonSize="genre"
-              fontSize="small"
-              scheme="genreActive"
-              borderRadius="round"
-              disableHoverOverlay={true}
-              key={genre.id}
-            >
-              {genre.name} <span className="emoji">{genre.emoji}</span>
-            </Button>
-          ))
-        )}
+        {movie.genres.map((genre) => (
+          <Button
+            buttonSize="genre"
+            fontSize="small"
+            scheme="genreActive"
+            borderRadius="round"
+            disableHoverOverlay={true}
+            key={genre.id}
+          >
+            {genre.name} <span className="emoji">{genre.emoji}</span>
+          </Button>
+        ))}
       </div>
 
       <Title size="small" color="thirdText" className="header">
         TV 시리즈
       </Title>
       <div className="genre-buttons">
-        {tv.genres.length === 0 ? (
-          <div className="empty-wrapper">
-            <Empty text="TV 시리즈 취향이 없습니다" height="32px" />
-          </div>
-        ) : (
-          tv.genres.map((genre) => (
-            <Button
-              buttonSize="genre"
-              fontSize="small"
-              scheme="genreActive"
-              borderRadius="round"
-              disableHoverOverlay={true}
-              key={genre.id}
-            >
-              {genre.name} <span className="emoji">{genre.emoji}</span>
-            </Button>
-          ))
-        )}
+        {tv.genres.map((genre) => (
+          <Button
+            buttonSize="genre"
+            fontSize="small"
+            scheme="genreActive"
+            borderRadius="round"
+            disableHoverOverlay={true}
+            key={genre.id}
+          >
+            {genre.name} <span className="emoji">{genre.emoji}</span>
+          </Button>
+        ))}
       </div>
     </UserPreferenceListStyle>
   );
 };
 
 const UserPreferenceListStyle = styled.div`
-
-.genre-buttons {
+  .genre-buttons {
     display: flex;
     flex-wrap: wrap;
     gap: 20px;
@@ -72,16 +70,17 @@ const UserPreferenceListStyle = styled.div`
     margin-bottom: 24px;
     width: 800px;
   }
+
   .emoji {
     display: inline-block;
     margin-right: none;
     margin-left: 4px;
-    
   }
+
   .empty-wrapper {
     width: 100%;
     display: flex;
-    justify-content: center; /* 가운데 정렬 */
+    justify-content: center;
   }
 `;
 

--- a/src/features/user/preference/ui/UserPreferenceList.tsx
+++ b/src/features/user/preference/ui/UserPreferenceList.tsx
@@ -41,7 +41,7 @@ const UserPreferenceList = () => {
       <div className="genre-buttons">
         {tv.genres.length === 0 ? (
           <div className="empty-wrapper">
-            <Empty text="TV 시리즈 취향이 없습니다" />
+            <Empty text="TV 시리즈 취향이 없습니다" height="32px" />
           </div>
         ) : (
           tv.genres.map((genre) => (

--- a/src/features/user/preference/ui/UserPreferenceList.tsx
+++ b/src/features/user/preference/ui/UserPreferenceList.tsx
@@ -16,7 +16,9 @@ const UserPreferenceList = () => {
       </Title>
       <div className="genre-buttons">
         {movie.genres.length === 0 ? (
-          <Empty text="영화 취향이 없습니다" />
+          <div className="empty-wrapper">
+            <Empty text="영화 취향이 없습니다" />
+          </div>
         ) : (
           movie.genres.map((genre) => (
             <Button
@@ -38,7 +40,9 @@ const UserPreferenceList = () => {
       </Title>
       <div className="genre-buttons">
         {tv.genres.length === 0 ? (
-          <Empty text="TV 시리즈 취향이 없습니다" />
+          <div className="empty-wrapper">
+            <Empty text="TV 시리즈 취향이 없습니다" />
+          </div>
         ) : (
           tv.genres.map((genre) => (
             <Button
@@ -59,6 +63,7 @@ const UserPreferenceList = () => {
 };
 
 const UserPreferenceListStyle = styled.div`
+
 .genre-buttons {
     display: flex;
     flex-wrap: wrap;
@@ -72,6 +77,11 @@ const UserPreferenceListStyle = styled.div`
     margin-right: none;
     margin-left: 4px;
     
+  }
+  .empty-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center; /* 가운데 정렬 */
   }
 `;
 

--- a/src/features/user/profile/hooks/useGetUserProfile.ts
+++ b/src/features/user/profile/hooks/useGetUserProfile.ts
@@ -1,11 +1,29 @@
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { fetchUserProfile, LocalUser, OAuthUser } from 'entities/user/model';
+import { useEffect } from 'react';
+import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useGetUserProfile = () => {
-  const { data, isLoading, isError, error } = useQuery<LocalUser | OAuthUser>({
+export const useGetUserProfile = (option?: {
+  onSuccess?: (data: LocalUser | OAuthUser) => void;
+  onError?: (error: AxiosError<CustomErrorResponse>) => void;
+}) => {
+  const { data, isLoading, isError, error } = useQuery<
+    LocalUser | OAuthUser,
+    AxiosError<CustomErrorResponse>
+  >({
     queryKey: ['profile'],
     queryFn: fetchUserProfile,
   });
+
+  // 후처리 함수 실행
+  useEffect(() => {
+    if (data) option?.onSuccess?.(data);
+  }, [data, option?.onSuccess]);
+
+  useEffect(() => {
+    if (error) option?.onError?.(error);
+  }, [error, option?.onError]);
 
   return {
     data,

--- a/src/features/user/profile/hooks/useUpdateUserProfile.ts
+++ b/src/features/user/profile/hooks/useUpdateUserProfile.ts
@@ -1,19 +1,32 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { updateProfile } from 'entities/user/model';
-import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
+import {
+  CustomErrorResponse,
+  CustomValidationErrorResponse,
+} from 'shared/types/CustomErrorResponse';
 
-export const useUpdateUserProfile = () => {
+export const useUpdateUserProfile = (option?: {
+  onSuccess?: () => void;
+  onError?: (
+    error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+  ) => void;
+}) => {
   const queryClient = useQueryClient();
 
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     AxiosResponse,
-    AxiosError<CustomErrorResponse>,
+    AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
     FormData
   >({
     mutationFn: updateProfile,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['profile'] });
+      option?.onSuccess?.();
+    },
+    onError: (err) => {
+      console.error('프로필 업데이트 실패:', err);
+      option?.onError?.(err);
     },
   });
   return {

--- a/src/features/user/profile/ui/UserProfileForm.tsx
+++ b/src/features/user/profile/ui/UserProfileForm.tsx
@@ -2,7 +2,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { LocalUser, OAuthUser } from 'entities/user/model';
 import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
+import { isValidationError } from 'shared/types/CustomErrorResponse';
 import { Button, InputText } from 'shared/ui';
+import { setErrorFromServer } from 'shared/validation/setErrorFromServer';
+import { toast } from 'sonner';
 import styled from 'styled-components';
 import { useUpdateUserProfile } from '../hooks/useUpdateUserProfile';
 import {
@@ -16,7 +19,24 @@ interface Props {
 }
 
 const UserProfileForm = ({ user }: Props) => {
-  const { mutate, isPending } = useUpdateUserProfile();
+  const { mutate, isPending } = useUpdateUserProfile({
+    onSuccess: () => {
+      toast.success('프로필이 수정되었습니다!');
+    },
+    onError: (error) => {
+      console.error('프로필 수정 실패:', error.response?.data);
+
+      if (isValidationError(error)) {
+        // 백엔드에서 받은 유효성 에러를 폼에 띄움
+        setErrorFromServer<UserProfileFormValues>(error, setError);
+      } else {
+        // 일반적인 에러 처리
+        const message =
+          error.response?.data?.message || '프로필을 수정하지 못했어요.';
+        toast.error(message as string);
+      }
+    },
+  });
   const { nickname, image } = user;
 
   const {
@@ -24,6 +44,7 @@ const UserProfileForm = ({ user }: Props) => {
     handleSubmit,
     reset,
     formState: { errors },
+    setError,
   } = useForm<UserProfileFormValues>({
     resolver: zodResolver(userProfileSchema),
     defaultValues: {

--- a/src/features/user/profile/ui/UserProfileImage.tsx
+++ b/src/features/user/profile/ui/UserProfileImage.tsx
@@ -48,7 +48,13 @@ const UserProfileImage = forwardRef<HTMLInputElement, UserProfileImageProps>(
             onChange={handleFileChange}
           />
 
-          <FileUploadButton type="button" onClick={handleFileClick}>
+          <FileUploadButton
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation(); // 버블링 막기
+              handleFileClick();
+            }}
+          >
             <Plus />
           </FileUploadButton>
 

--- a/src/shared/mocks/handlers/authHandlers.ts
+++ b/src/shared/mocks/handlers/authHandlers.ts
@@ -3,7 +3,7 @@ import {
   SignupRequestType,
   UpdatePasswordRequestType,
 } from 'entities/auth/model/types/auth.type';
-import { http } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { createErrorResponse, createSuccessResponse } from '../utils/response';
 
 const BASE = import.meta.env.VITE_API_BASE_URL;
@@ -25,6 +25,19 @@ export const authHandlers = [
         409,
         '이미 가입된 계정입니다 (undefined)',
         'ALREADY_REGISTERED_ACCOUNT',
+      );
+    }
+    if (body.nickname === 'invalid') {
+      return HttpResponse.json(
+        {
+          statusCode: 400,
+          message: {
+            nickname: ['이미 존재하는 닉네임입니다.'],
+          },
+          error: 'VALIDATION_ERROR',
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 },
       );
     }
 

--- a/src/shared/mocks/handlers/preferenceHandler.ts
+++ b/src/shared/mocks/handlers/preferenceHandler.ts
@@ -3,14 +3,14 @@ import { http } from 'msw';
 import { createErrorResponse, createSuccessResponse } from '../utils/response';
 
 const userPreference = {
-  movies: {
+  movie: {
     genres: [
       { id: 28, name: '액션', emoji: '🔫' },
       { id: 12, name: '모험', emoji: '🧭' },
     ],
     count: 8,
   },
-  tvs: {
+  tv: {
     genres: [
       { id: 10759, name: '액션 & 어드벤처', emoji: '🗡️' },
       { id: 16, name: '애니메이션', emoji: '🎨' },
@@ -24,19 +24,19 @@ const userPreference = {
   },
 };
 
-// const _emptyPreference = {
-//   movies: {
-//     genres: [
-//       { id: 28, name: '액션', emoji: '🔫' },
-//       { id: 12, name: '모험', emoji: '🧭' },
-//     ],
-//     count: 8,
-//   },
-//   tvs: {
-//     genres: [],
-//     count: 0,
-//   },
-// };
+const _emptyPreference = {
+  movie: {
+    genres: [
+      { id: 28, name: '액션', emoji: '🔫' },
+      { id: 12, name: '모험', emoji: '🧭' },
+    ],
+    count: 8,
+  },
+  tv: {
+    genres: [],
+    count: 0,
+  },
+};
 
 export const preferenceHandlers = [
   http.put(
@@ -62,21 +62,21 @@ export const preferenceHandlers = [
   http.get(
     `${import.meta.env.VITE_API_BASE_URL}/users/preferences`,
     async () => {
-      return createSuccessResponse(undefined, userPreference);
+      return createSuccessResponse(undefined, _emptyPreference);
     },
   ),
 
   http.get(
     `${import.meta.env.VITE_API_BASE_URL}/users/preferences/movies`,
     async () => {
-      return createSuccessResponse(undefined, userPreference.movies);
+      return createSuccessResponse(undefined, userPreference.movie);
     },
   ),
 
   http.get(
     `${import.meta.env.VITE_API_BASE_URL}/users/preferences/tvs`,
     async () => {
-      return createSuccessResponse(undefined, userPreference.tvs);
+      return createSuccessResponse(undefined, userPreference.tv);
     },
   ),
 ];

--- a/src/shared/types/CustomErrorResponse.ts
+++ b/src/shared/types/CustomErrorResponse.ts
@@ -1,5 +1,46 @@
+import { AxiosError } from 'axios';
+
 export interface CustomErrorResponse {
-  status: number;
+  statusCode: number;
   message: string;
-  errorCode: string;
+  error: ErrorCode;
+  timestamp?: string;
+}
+
+export interface CustomValidationErrorResponse {
+  statusCode: 400;
+  message: Record<string, string[]>;
+  error: ErrorCode.VALIDATION_ERROR;
+  timestamp?: string;
+}
+
+export function isValidationError(
+  error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+): error is AxiosError<CustomValidationErrorResponse> {
+  return error.response?.data?.error === ErrorCode.VALIDATION_ERROR;
+}
+
+export enum ErrorCode {
+  DUPLICATE_NICKNAME = 'DUPLICATE_NICKNAME',
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+  DUPLICATE_EMAIL = 'DUPLICATE_EMAIL',
+  ALREADY_REGISTERED_ACCOUNT = 'ALREADY_REGISTERED_ACCOUNT',
+  INVALID_CREDENTIALS = 'INVALID_CREDENTIALS',
+  OAUTH_ACCOUNT_LOGIN = 'OAUTH_ACCOUNT_LOGIN',
+  USER_NOT_FOUND = 'USER_NOT_FOUND',
+  INVALID_REFRESH_TOKEN = 'INVALID_REFRESH_TOKEN',
+  OAUTH_ACCOUNT_PASSWORD_CHANGE = 'OAUTH_ACCOUNT_PASSWORD_CHANGE',
+  INVALID_CURRENT_PASSWORD = 'INVALID_CURRENT_PASSWORD',
+  UNIQUE_NICKNAME_GENERATION_FAILED = 'UNIQUE_NICKNAME_GENERATION_FAILED',
+  INVALID_GENRE_ID = 'INVALID_GENRE_ID',
+  INVALID_CONTENT_TYPE_KEY = 'INVALID_CONTENT_TYPE_KEY',
+  CONTENT_NOT_FOUND = 'CONTENT_NOT_FOUND',
+  TMDB_API_ERROR = 'TMDB_API_ERROR',
+  INVALID_PAGE = 'INVALID_PAGE',
+  S3_UPLOAD_FAILED = 'S3_UPLOAD_FAILED',
+  S3_DELETE_FAILED = 'S3_DELETE_FAILED',
+  COLLECTION_CREATE_FAILED = 'COLLECTION_CREATE_FAILED',
+  COLLECTION_DELETE_FAILED = 'COLLECTION_DELETE_FAILED',
+  COLLECTION_NOT_FOUND = 'COLLECTION_NOT_FOUND',
+  FORBIDDEN = 'FORBIDDEN',
 }

--- a/src/shared/ui/empty/empty.tsx
+++ b/src/shared/ui/empty/empty.tsx
@@ -6,11 +6,12 @@ interface EmptyProps {
   linkText?: string;
   linkTo?: To;
   state?: Record<string, unknown>;
+  height?: string;
 }
 
-export function Empty({ text, linkText, linkTo, state }: EmptyProps) {
+export function Empty({ text, linkText, linkTo, state, height }: EmptyProps) {
   return (
-    <StyledEmpty>
+    <StyledEmpty $height={height}>
       <Text>
         {text}
         {linkTo && linkText && (
@@ -23,11 +24,11 @@ export function Empty({ text, linkText, linkTo, state }: EmptyProps) {
   );
 }
 
-const StyledEmpty = styled.div`
+const StyledEmpty = styled.div<{ $height?: string }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 70vh;
+  height: ${({ $height }) => $height ?? '70vh'};
 `;
 
 const Text = styled.span`

--- a/src/shared/validation/setErrorFromServer.ts
+++ b/src/shared/validation/setErrorFromServer.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from 'axios';
+import { FieldValues, Path, UseFormSetError } from 'react-hook-form';
+import {
+  CustomErrorResponse,
+  CustomValidationErrorResponse,
+} from 'shared/types/CustomErrorResponse';
+
+export function setErrorFromServer<T extends FieldValues>(
+  error: AxiosError<CustomErrorResponse | CustomValidationErrorResponse>,
+  setError: UseFormSetError<T>,
+) {
+  const messages = error.response?.data.message;
+  if (!messages) return;
+
+  Object.entries(messages).forEach(([field, messages]) => {
+    const message = messages[0];
+    setError(field as Path<T>, {
+      type: 'server',
+      message,
+    });
+  });
+}


### PR DESCRIPTION
## 📌 개요
- 
## 🛠 작업 내용
- 기존에 작성한 훅에 onSuccess, onError 함수를 파라미터로 받아 옵션으로 지정할 수 있게 함. -> 에러 핸들링을 원하는 컴포넌트에서 원하는대로 할 수 있음
- CustomErrorResponse 타입 수정
- CustomValidationErrorResponse 타입추가 
- ErrorCode enum 작성
- 백엔드 발 유효성 에러 인풋창에 보여주는 함수 작성
- 컴포넌트 별 예외 핸들링
- AuthProvider 에서 리프레시 요청 전 로딩 렌더링 -> 리프레시 이전에 페이지 렌더링 방지효과
- 이미지 업로드창 두번 뜨는 오류 수정
- PreferenceList의 Empty 가운데 정렬
## ⚠️ 주의 사항
- 
## 🔗 관련 이슈
- 
