### PR TITLE
컬렉션 관련 오류 수정 

### DIFF
--- a/src/entities/collection/services/collectionApi.ts
+++ b/src/entities/collection/services/collectionApi.ts
@@ -46,13 +46,11 @@ export const updateCollection = async (
 
 export const addCollectionContents = async (
   id: number,
-  contentIds: number[],
+  contentId: number,
 ): Promise<string> => {
-  const response = await authClient.post(`/collections/${id}/contents`, null, {
-    params: {
-      contentId: contentIds,
-    },
-  });
+  const response = await authClient.post(
+    `/collections/${id}/contents/${contentId}`,
+  );
   return response.data;
 };
 

--- a/src/entities/collection/types/collection.type.ts
+++ b/src/entities/collection/types/collection.type.ts
@@ -1,10 +1,4 @@
-import { ContentType } from 'entities/contents/model/types/contents.type';
-export interface CollectionContent {
-  id: number;
-  posterPath: string | null;
-  title: string;
-  contentType: ContentType;
-}
+import { Contents } from 'entities/contents/model/types/contents.type';
 export interface CollectionBase {
   title: string;
   description: string;
@@ -24,7 +18,7 @@ export interface GetCollectionsResponse {
 }
 export interface GetCollectionDetailResponse extends CollectionBase {
   id: number;
-  contents: CollectionContent[];
+  contents: Contents[];
 }
 
 export type UpdateCollectionRequest = FormData;

--- a/src/entities/contents/model/types/contents.type.ts
+++ b/src/entities/contents/model/types/contents.type.ts
@@ -5,7 +5,7 @@ export interface Contents {
   id: number;
   posterPath: string | null;
   title: string;
-  contentType?: ContentType;
+  contentType: ContentType;
 }
 
 export interface ParameterTypes {

--- a/src/features/collection/hooks/useAddCollectionContents.ts
+++ b/src/features/collection/hooks/useAddCollectionContents.ts
@@ -3,17 +3,20 @@ import { AxiosError } from 'axios';
 import { addCollectionContents } from 'entities/collection';
 import { CustomErrorResponse } from 'shared/types/CustomErrorResponse';
 
-export const useAddCollectionContents = (id: number) => {
+export const useAddCollectionContents = (contentId: number) => {
   const queryClient = useQueryClient();
 
   const { mutate, isPending, isSuccess, isError, error } = useMutation<
     string,
     AxiosError<CustomErrorResponse>,
-    number[]
+    number
   >({
-    mutationFn: (contentIds) => addCollectionContents(id, contentIds),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['collections', id] });
+    mutationFn: (collectionId) =>
+      addCollectionContents(collectionId, contentId),
+    onSuccess: (_, collectionId) => {
+      queryClient.invalidateQueries({
+        queryKey: ['collections', collectionId],
+      });
     },
   });
 

--- a/src/features/contents/ui/ContentsList/ContentsSelector.tsx
+++ b/src/features/contents/ui/ContentsList/ContentsSelector.tsx
@@ -1,4 +1,4 @@
-import { CollectionContent } from 'entities/collection';
+import { Contents } from 'entities/contents/model';
 import { Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import ContentItemEdit from '../ContentItem/ContentItemEdit';
@@ -7,7 +7,7 @@ import { Header, Wrapper } from './ContentsList.stye';
 
 interface Props {
   title: string;
-  contents: CollectionContent[];
+  contents: Contents[];
   selectedContents: number[];
   setter: Dispatch<SetStateAction<number[]>>;
 }

--- a/src/shared/mocks/handlers/collectionHandlers.ts
+++ b/src/shared/mocks/handlers/collectionHandlers.ts
@@ -1,9 +1,7 @@
-import {
-  CollectionBase,
-  GetCollectionDetailResponse,
-} from 'entities/collection/types/collection.type';
+import { GetCollectionDetailResponse } from 'entities/collection/types/collection.type';
 import { http } from 'msw';
 import { createErrorResponse, createSuccessResponse } from '../utils/response';
+import { mockContents } from './contentsHandlers';
 
 const mockCollections: GetCollectionDetailResponse[] = [
   {
@@ -13,144 +11,13 @@ const mockCollections: GetCollectionDetailResponse[] = [
     thumbnail:
       'https://images.unsplash.com/photo-1618005198919-d3d4b5a92ead?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     contents: [
-      {
-        id: 101,
-        title: 'Mock Movie 1',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 102,
-        title: 'Mock TV Show',
-        posterPath: '/2VUmvqsHb6cEtdfscEA6fqqVzLg.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 103,
-        title: 'Mock TV Show',
-        posterPath: null,
-        contentType: 'tv',
-      },
-      {
-        id: 104,
-        title: 'Mock Movie 1',
-        posterPath: '/2VUmvqsHb6cEtdfscEA6fqqVzLg.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 105,
-        title: 'Mock TV Show',
-        posterPath: '/2VUmvqsHb6cEtdfscEA6fqqVzLg.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 106,
-        title: 'Mock Movie 1',
-        posterPath: '/2vHQBX5L4yoExTa55KmGIg2Q5s3.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 107,
-        title: 'Mock TV Show',
-        posterPath: '/hqcexYHbiTBfDIdDWxrxPtVndBX.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 108,
-        title: 'Mock Movie 1',
-        posterPath: '/q0fGCmjLu42MPlSO9OYWpI5w86I.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 109,
-        title: 'Mock TV Show',
-        posterPath: '/AEgggzRr1vZCLY86MAp93li43z.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 110,
-        title: 'Mock Movie 1',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 111,
-        title: 'Mock TV Show',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 112,
-        title: 'Mock Movie 1',
-        posterPath: '/tObSf1VzzHt9xB0csanFtb3DRjf.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 113,
-        title: 'Mock TV Show',
-        posterPath: '/7c5VBuCbjZOk7lSfj9sMpmDIaKX.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 114,
-        title: 'Mock Movie 1',
-        posterPath: '/43c1efKzA1kigNzY0HBzeoXp8LR.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 115,
-        title: 'Dora and the Search for Sol Dorado',
-        posterPath: '/r3d6u2n7iPoWNsSWwlJJWrDblOH.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 116,
-        title: 'Mock Movie 1',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 117,
-        title: '室町無頼',
-        posterPath: '/6U0i0HsSCvhRW4IpGzdead6QRo3.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 118,
-        title: 'The Ritual',
-        posterPath: '/ktqPs5QyuF8SpKnipvVHb3fwD8d.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 119,
-        title: 'Mock TV Show',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 120,
-        title: 'Mock Movie 1',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 121,
-        title: 'Mock TV Show',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'tv',
-      },
-      {
-        id: 122,
-        title: 'Mock Movie 1',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'movie',
-      },
-      {
-        id: 123,
-        title: 'Mock TV Show',
-        posterPath: '/6WxhEvFsauuACfv8HyoVX6mZKFj.jpg',
-        contentType: 'tv',
-      },
+      mockContents[0],
+      mockContents[1],
+      mockContents[2],
+      mockContents[3],
+      mockContents[4],
+      mockContents[5],
+      mockContents[6],
     ],
   },
   {
@@ -167,7 +34,12 @@ let nextId = 3;
 
 export const collectionHandlers = [
   http.post('/collections', async ({ request }) => {
-    const body = (await request.json()) as CollectionBase; // image string 값으로 처리
+    const formData = await request.formData();
+    const body = {
+      title: formData.get('title') as string,
+      description: formData.get('description') as string,
+      thumbnail: formData.get('thumbnail') as string,
+    };
 
     const newCollection: GetCollectionDetailResponse = {
       id: nextId++,
@@ -214,7 +86,6 @@ export const collectionHandlers = [
 
   http.patch('/collections/:id', async ({ params, request }) => {
     const { id } = params;
-    const patchData = (await request.json()) as CollectionBase; // image string 값으로 처리
 
     const idx = mockCollections.findIndex((c) => c.id === Number(id));
     if (idx === -1) {
@@ -224,19 +95,32 @@ export const collectionHandlers = [
         'COLLECTION_NOT_FOUND',
       );
     }
+    const formData = await request.formData();
+    const patchData: Partial<GetCollectionDetailResponse> = {};
 
-    mockCollections[idx] = { ...mockCollections[idx], ...patchData };
+    if (formData.get('title') !== null) {
+      patchData.title = formData.get('title') as string;
+    }
+    if (formData.get('description') !== null) {
+      patchData.description = formData.get('description') as string;
+    }
+    if (formData.get('thumbnail') !== null) {
+      patchData.thumbnail = formData.get('thumbnail') as string;
+    }
+
+    mockCollections[idx] = {
+      ...mockCollections[idx],
+      ...patchData,
+    };
 
     return createSuccessResponse('컬렉션 수정 완료');
   }),
 
-  http.post('/collections/:id/contents', async ({ params, request }) => {
-    const { id } = params;
-    const url = new URL(request.url);
-    const contentIds = url.searchParams.getAll('contentId').map(Number);
+  http.post('/collections/:collectionId/contents/:contentId', async (req) => {
+    const { collectionId, contentId } = req.params;
 
-    const idx = mockCollections.findIndex((c) => c.id === Number(id));
-    if (idx === -1) {
+    const target = mockCollections.find((c) => c.id === Number(collectionId));
+    if (!target) {
       return createErrorResponse(
         404,
         '컬렉션을 찾을 수 없습니다.',
@@ -244,18 +128,21 @@ export const collectionHandlers = [
       );
     }
 
-    const newContents = contentIds
-      .filter((cid) => !mockCollections[idx].contents.some((c) => c.id === cid))
-      .map((cid) => ({
-        id: cid,
-        title: `Mock Content ${cid}`,
-        posterPath: null,
-        contentType: cid % 2 === 0 ? ('movie' as const) : ('tv' as const),
-      }));
+    const content = mockContents.find((c) => c.id === Number(contentId));
+    if (!content) {
+      return createErrorResponse(
+        404,
+        '콘텐츠를 찾을 수 없습니다.',
+        'CONTENT_NOT_FOUND',
+      );
+    }
 
-    mockCollections[idx].contents.push(...newContents);
+    const alreadyExists = target.contents.some((c) => c.id === content.id);
+    if (!alreadyExists) {
+      target.contents.push(content);
+    }
 
-    return createSuccessResponse('콘텐츠 추가 완료');
+    return createSuccessResponse('콘텐츠가 컬렉션에 추가되었습니다.');
   }),
 
   http.delete('/collections/:id/contents', async ({ params, request }) => {

--- a/src/shared/mocks/handlers/contentsHandlers.ts
+++ b/src/shared/mocks/handlers/contentsHandlers.ts
@@ -20,15 +20,13 @@ export const mockGenres: Genre[] = [
 export const mockContents: Contents[] = [
   {
     id: 1,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/zTgjeblxSLSvomt6F6UYtpiD4n7.jpg',
+    posterPath: '/zTgjeblxSLSvomt6F6UYtpiD4n7.jpg',
     title: 'Inception',
     contentType: 'movie',
   },
   {
     id: 2,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/ygr4hE8Qpagv8sxZbMw1mtYkcQE.jpg',
+    posterPath: '/ygr4hE8Qpagv8sxZbMw1mtYkcQE.jpg',
     title: '쥬라기 월드: 새로운 시작',
     contentType: 'movie',
   },
@@ -41,15 +39,13 @@ export const mockContents: Contents[] = [
 
   {
     id: 4,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/evoEi8SBSvIIEveM3V6nCJ6vKj8.jpg',
+    posterPath: '/evoEi8SBSvIIEveM3V6nCJ6vKj8.jpg',
     title: 'Interstellar',
     contentType: 'movie',
   },
   {
     id: 5,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
+    posterPath: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
     title: 'Breaking Bad',
     contentType: 'tv',
   },
@@ -61,15 +57,13 @@ export const mockContents: Contents[] = [
   },
   {
     id: 7,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
+    posterPath: '/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
     title: 'Squid Game',
     contentType: 'tv',
   },
   {
     id: 8,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/yz4r477D8lljEF7xorrv3zvQxls.jpg',
+    posterPath: '/yz4r477D8lljEF7xorrv3zvQxls.jpg',
     title: 'Stranger Things',
     contentType: 'tv',
   },
@@ -85,8 +79,7 @@ export const mockContentsResponse: ContentsResponse = {
 export const mockMovies: Movie[] = [
   {
     id: 301,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/fxBxoXFAYKWde6lKzXxSusn18Av.jpg',
+    posterPath: '/fxBxoXFAYKWde6lKzXxSusn18Av.jpg',
     title: 'The Matrix',
     contentType: 'movie',
     originalLanguage: 'en',
@@ -101,8 +94,7 @@ export const mockMovies: Movie[] = [
   },
   {
     id: 302,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/mSi0gskYpmf1FbXngM37s2HppXh.jpg',
+    posterPath: '/mSi0gskYpmf1FbXngM37s2HppXh.jpg',
     title: '기생충',
     contentType: 'movie',
     originalLanguage: 'ko',
@@ -117,8 +109,7 @@ export const mockMovies: Movie[] = [
   },
   {
     id: 303,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/z7ilT5rNN9kDo8JZmgyhM6ej2xv.jpg',
+    posterPath: '/z7ilT5rNN9kDo8JZmgyhM6ej2xv.jpg',
     title: 'Avengers: Endgame',
     contentType: 'movie',
     originalLanguage: 'en',
@@ -133,8 +124,7 @@ export const mockMovies: Movie[] = [
   },
   {
     id: 304,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/iraQz6gdAe8JL45QcBifM1UhQ38.jpg',
+    posterPath: '/iraQz6gdAe8JL45QcBifM1UhQ38.jpg',
     title: 'Forrest Gump',
     contentType: 'movie',
     originalLanguage: 'en',
@@ -170,8 +160,7 @@ export const mockMovies: Movie[] = [
 export const mockTVs: TVs[] = [
   {
     id: 401,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
+    posterPath: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
     title: 'Breaking Bad',
     contentType: 'tv',
     originalLanguage: 'en',
@@ -188,20 +177,18 @@ export const mockTVs: TVs[] = [
       {
         id: 1,
         title: 'Season 1',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
+        posterPath: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
       },
       {
         id: 2,
         title: 'Season 2',
-        posterPath: 'https://www.themoviedb.org/t/p/w1280/breakingbad_s2.jpg',
+        posterPath: '/breakingbad_s2.jpg',
       },
     ],
   },
   {
     id: 402,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
+    posterPath: '/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
     title: '오징어 게임',
     contentType: 'tv',
     originalLanguage: 'ko',
@@ -221,15 +208,13 @@ export const mockTVs: TVs[] = [
       {
         id: 1,
         title: 'Season 1',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
+        posterPath: '/yACIAqAkSLkX4coHafpyLWAtQjw.jpg',
       },
     ],
   },
   {
     id: 403,
-    posterPath:
-      'hhttps://www.themoviedb.org/t/p/w1280/mpOQpOKdo2XJnTqRzo1lTmDNsc1.jpg',
+    posterPath: 'h/mpOQpOKdo2XJnTqRzo1lTmDNsc1.jpg',
     title: 'Stranger Things',
     contentType: 'tv',
     originalLanguage: 'en',
@@ -246,21 +231,18 @@ export const mockTVs: TVs[] = [
       {
         id: 1,
         title: 'Season 1',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/mpOQpOKdo2XJnTqRzo1lTmDNsc1.jpg',
+        posterPath: '/mpOQpOKdo2XJnTqRzo1lTmDNsc1.jpg',
       },
       {
         id: 2,
         title: 'Season 2',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/strangerthings_s2.jpg',
+        posterPath: '/strangerthings_s2.jpg',
       },
     ],
   },
   {
     id: 404,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/1qbiyfmJe7tu4QpqCz5flW93mKj.jpg',
+    posterPath: '/1qbiyfmJe7tu4QpqCz5flW93mKj.jpg',
     title: '우리들의 블루스',
     contentType: 'tv',
     originalLanguage: 'ko',
@@ -277,15 +259,13 @@ export const mockTVs: TVs[] = [
       {
         id: 1,
         title: 'Season 1',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/1qbiyfmJe7tu4QpqCz5flW93mKj.jpg',
+        posterPath: '/1qbiyfmJe7tu4QpqCz5flW93mKj.jpg',
       },
     ],
   },
   {
     id: 405,
-    posterPath:
-      'https://www.themoviedb.org/t/p/w1280/qZMEiTsNlCQV27hHQE27ZtlPWyv.jpg',
+    posterPath: '/qZMEiTsNlCQV27hHQE27ZtlPWyv.jpg',
     title: '도깨비',
     contentType: 'tv',
     originalLanguage: 'ko',
@@ -302,8 +282,7 @@ export const mockTVs: TVs[] = [
       {
         id: 1,
         title: 'Season 1',
-        posterPath:
-          'https://www.themoviedb.org/t/p/w1280/qZMEiTsNlCQV27hHQE27ZtlPWyv.jpg',
+        posterPath: '/qZMEiTsNlCQV27hHQE27ZtlPWyv.jpg',
       },
     ],
   },


### PR DESCRIPTION
## 📌 개요
- 컬렉션 관련 오류 수정 
## 🛠 작업 내용
- 컨텐츠 아이디 number[] 에서 number로 수정, 훅스에서 contentId를 파라미터로 고정
- 겹치는 타입 삭제 및 컬렉션, 콘텐츠 mock 핸들러 오류 수정
## ⚠️ 주의 사항
- x
## 🔗 관련 이슈
- x
